### PR TITLE
Update fuelCrossFeed rules for stack parts

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,5 +1,9 @@
 ChangeLog
 
+0.9.7.1
+	Thanks to @John-McFly for this:
+		Setting 'fuelCrossFeed = True' properly on stack LFO tanks.
+		
 0.9.7
 	Updated for KSP 1.8
 

--- a/GameData/MI_FTX_license.txt
+++ b/GameData/MI_FTX_license.txt
@@ -1,6 +1,6 @@
 This work is licensed under a Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License.
 
 This package redistributes the following plugins, their license information can be found in the provided links:
-Interstellar Fuel Switch - made by FreeThinker - http://forum.kerbalspaceprogram.com/threads/117932-1-0-4-Interstellar-Fuel-Switch-1-16-(updated-12-9-2015)
-ModuleManager - made by Sarbian & Ialdabaoth - http://forum.kerbalspaceprogram.com/threads/55219-Module-Manager-1-5-6-%28Jan-6%29
-CrossFeedEnabler - made by NathanKell - http://forum.kerbalspaceprogram.com/threads/76499-0-90-CrossFeedEnabler-v3-2-Dec-20-14
+Interstellar Fuel Switch - made by FreeThinker - https://forum.kerbalspaceprogram.com/index.php?/topic/106243-181-1112-interstellar-fuel-switch-ifs-3294/
+ModuleManager - made by Sarbian & Ialdabaoth - https://forum.kerbalspaceprogram.com/index.php?/topic/50533-18x-112x-module-manager-421-august-1st-2021-locked-inside-edition/
+CrossFeedEnabler - made by NathanKell - https://forum.kerbalspaceprogram.com/index.php?/topic/69286-10-crossfeedenabler-v33-may-11/

--- a/GameData/MunarIndustries/Parts/FuelTank/FiveM_Tanks/FiveM_Adapt.cfg
+++ b/GameData/MunarIndustries/Parts/FuelTank/FiveM_Tanks/FiveM_Adapt.cfg
@@ -42,6 +42,7 @@ crashTolerance = 7
 breakingForce = 300
 breakingTorque = 300
 maxTemp = 2200 // = 3200
+fuelCrossFeed = True
 bulkheadProfiles = size4, srf
 
 tags = #autoLOC_500498 //#autoLOC_500498 = fuel fueltank ?lfo liquid oxidizer propellant rocket tank

--- a/GameData/MunarIndustries/Parts/FuelTank/FiveM_Tanks/FiveM_Adapt_S.cfg
+++ b/GameData/MunarIndustries/Parts/FuelTank/FiveM_Tanks/FiveM_Adapt_S.cfg
@@ -42,6 +42,7 @@ crashTolerance = 7
 breakingForce = 300
 breakingTorque = 300
 maxTemp = 2200 // = 3200
+fuelCrossFeed = True
 bulkheadProfiles = size4, srf
 tags = #autoLOC_500498 //#autoLOC_500498 = fuel fueltank ?lfo liquid oxidizer propellant rocket tank
 

--- a/GameData/MunarIndustries/Parts/FuelTank/FiveM_Tanks/FiveM_Cone.cfg
+++ b/GameData/MunarIndustries/Parts/FuelTank/FiveM_Tanks/FiveM_Cone.cfg
@@ -41,6 +41,7 @@ crashTolerance = 7
 breakingForce = 300
 breakingTorque = 300
 maxTemp = 2200 // = 3200
+fuelCrossFeed = True
 bulkheadProfiles = size4, srf
 tags = #autoLOC_500498 //#autoLOC_500498 = fuel fueltank ?lfo liquid oxidizer propellant rocket tank
 

--- a/GameData/MunarIndustries/Parts/FuelTank/FiveM_Tanks/FiveM_Dome.cfg
+++ b/GameData/MunarIndustries/Parts/FuelTank/FiveM_Tanks/FiveM_Dome.cfg
@@ -42,6 +42,7 @@ crashTolerance = 7
 breakingForce = 300
 breakingTorque = 300
 maxTemp = 2200 // = 3200
+fuelCrossFeed = True
 bulkheadProfiles = size4, srf
 tags = #autoLOC_500498 //#autoLOC_500498 = fuel fueltank ?lfo liquid oxidizer propellant rocket tank
 

--- a/GameData/MunarIndustries/Parts/FuelTank/FiveM_Tanks/FiveM_Tank_L.cfg
+++ b/GameData/MunarIndustries/Parts/FuelTank/FiveM_Tanks/FiveM_Tank_L.cfg
@@ -42,6 +42,7 @@ crashTolerance = 7
 breakingForce = 300
 breakingTorque = 300
 maxTemp = 2200 // = 3200
+fuelCrossFeed = True
 bulkheadProfiles = size4, srf
 tags = #autoLOC_500498 //#autoLOC_500498 = fuel fueltank ?lfo liquid oxidizer propellant rocket tank
 

--- a/GameData/MunarIndustries/Parts/FuelTank/FiveM_Tanks/FiveM_Tank_M.cfg
+++ b/GameData/MunarIndustries/Parts/FuelTank/FiveM_Tanks/FiveM_Tank_M.cfg
@@ -42,6 +42,7 @@ crashTolerance = 7
 breakingForce = 300
 breakingTorque = 300
 maxTemp = 2200 // = 3200
+fuelCrossFeed = True
 bulkheadProfiles = size4, srf
 tags = #autoLOC_500498 //#autoLOC_500498 = fuel fueltank ?lfo liquid oxidizer propellant rocket tank
 

--- a/GameData/MunarIndustries/Parts/FuelTank/FiveM_Tanks/FiveM_Tank_S.cfg
+++ b/GameData/MunarIndustries/Parts/FuelTank/FiveM_Tanks/FiveM_Tank_S.cfg
@@ -42,6 +42,7 @@ crashTolerance = 7
 breakingForce = 300
 breakingTorque = 300
 maxTemp = 2200 // = 3200
+fuelCrossFeed = True
 bulkheadProfiles = size4, srf
 tags = #autoLOC_500498 //#autoLOC_500498 = fuel fueltank ?lfo liquid oxidizer propellant rocket tank
 

--- a/GameData/MunarIndustries/Parts/FuelTank/FiveM_Tanks/WagonWheel.cfg
+++ b/GameData/MunarIndustries/Parts/FuelTank/FiveM_Tanks/WagonWheel.cfg
@@ -42,6 +42,7 @@ crashTolerance = 7
 breakingForce = 300
 breakingTorque = 300
 maxTemp = 2200 // = 3200
+fuelCrossFeed = True
 bulkheadProfiles = size4, srf
 tags = #autoLOC_500498 //#autoLOC_500498 = fuel fueltank ?lfo liquid oxidizer propellant rocket tank
 

--- a/GameData/MunarIndustries/Parts/FuelTank/Jumbo_32/Jumbo_32.cfg
+++ b/GameData/MunarIndustries/Parts/FuelTank/Jumbo_32/Jumbo_32.cfg
@@ -42,6 +42,7 @@ crashTolerance = 6
 breakingForce = 200
 breakingTorque = 200
 maxTemp = 2000 // = 2900
+fuelCrossFeed = True
 bulkheadProfiles = size2, srf
 tags = #autoLOC_500498 //#autoLOC_500498 = fuel fueltank ?lfo liquid oxidizer propellant rocket tank
 

--- a/GameData/MunarIndustries/Parts/FuelTank/Jumbo_Shapes/Jumbo_Cone.cfg
+++ b/GameData/MunarIndustries/Parts/FuelTank/Jumbo_Shapes/Jumbo_Cone.cfg
@@ -41,6 +41,7 @@ crashTolerance = 6
 breakingForce = 200
 breakingTorque = 200
 maxTemp = 2000 // = 2900
+fuelCrossFeed = True
 bulkheadProfiles = size2, srf
 tags = #autoLOC_500498 //#autoLOC_500498 = fuel fueltank ?lfo liquid oxidizer propellant rocket tank
 

--- a/GameData/MunarIndustries/Parts/FuelTank/Jumbo_Shapes/Jumbo_Dome.cfg
+++ b/GameData/MunarIndustries/Parts/FuelTank/Jumbo_Shapes/Jumbo_Dome.cfg
@@ -42,6 +42,7 @@ crashTolerance = 6
 breakingForce = 200
 breakingTorque = 200
 maxTemp = 2000 // = 2900
+fuelCrossFeed = True
 bulkheadProfiles = size1, size2, srf
 tags = #autoLOC_500498 //#autoLOC_500498 = fuel fueltank ?lfo liquid oxidizer propellant rocket tank
 

--- a/GameData/MunarIndustries/Parts/FuelTank/One25M_Tanks/One25M_Cone.cfg
+++ b/GameData/MunarIndustries/Parts/FuelTank/One25M_Tanks/One25M_Cone.cfg
@@ -40,6 +40,7 @@ crashTolerance = 6
 breakingForce = 50
 breakingTorque = 50
 maxTemp = 2000 // = 2900
+fuelCrossFeed = True
 bulkheadProfiles = size1, srf
 tags = #autoLOC_500498 //#autoLOC_500498 = fuel fueltank ?lfo liquid oxidizer propellant rocket tank
 

--- a/GameData/MunarIndustries/Parts/FuelTank/One25M_Tanks/One25M_Dome.cfg
+++ b/GameData/MunarIndustries/Parts/FuelTank/One25M_Tanks/One25M_Dome.cfg
@@ -41,6 +41,7 @@ crashTolerance = 6
 breakingForce = 50
 breakingTorque = 50
 maxTemp = 2000 // = 2900
+fuelCrossFeed = True
 bulkheadProfiles = size1, size0, srf
 tags = #autoLOC_500498 //#autoLOC_500498 = fuel fueltank ?lfo liquid oxidizer propellant rocket tank
 

--- a/GameData/MunarIndustries/Parts/FuelTank/One25M_Tanks/Puck.cfg
+++ b/GameData/MunarIndustries/Parts/FuelTank/One25M_Tanks/Puck.cfg
@@ -41,6 +41,7 @@ PART
 	breakingForce = 50
 	breakingTorque = 50
 	maxTemp = 2000 // = 2900
+	fuelCrossFeed = True
 	bulkheadProfiles = size1, srf
 	tags = #autoLOC_500498 //#autoLOC_500498 = fuel fueltank ?lfo liquid oxidizer propellant rocket tank
 	

--- a/GameData/MunarIndustries/Parts/FuelTank/Radial_Adapt_LG/Radial_Adapt_LG.cfg
+++ b/GameData/MunarIndustries/Parts/FuelTank/Radial_Adapt_LG/Radial_Adapt_LG.cfg
@@ -43,6 +43,7 @@ breakingForce = 200
 breakingTorque = 200
 fuelCrossFeed = True
 maxTemp = 2000 // = 3000
+fuelCrossFeed = True
 bulkheadProfiles = size1, srf
 	tags = #autoLOC_500498 //#autoLOC_500498 = fuel fueltank ?lfo liquid oxidizer propellant rocket tank
 

--- a/GameData/MunarIndustries/Parts/FuelTank/Radial_Adapt_LG/Radial_Adapt_LG_Slant_P.cfg
+++ b/GameData/MunarIndustries/Parts/FuelTank/Radial_Adapt_LG/Radial_Adapt_LG_Slant_P.cfg
@@ -43,6 +43,7 @@ breakingForce = 200
 breakingTorque = 200
 fuelCrossFeed = True
 maxTemp = 2000 // = 3000
+fuelCrossFeed = True
 bulkheadProfiles = size1, srf
 	tags = #autoLOC_500498 //#autoLOC_500498 = fuel fueltank ?lfo liquid oxidizer propellant rocket tank
 

--- a/GameData/MunarIndustries/Parts/FuelTank/Radial_Adapt_LG/Radial_Adapt_LG_Slant_S.cfg
+++ b/GameData/MunarIndustries/Parts/FuelTank/Radial_Adapt_LG/Radial_Adapt_LG_Slant_S.cfg
@@ -43,6 +43,7 @@ breakingForce = 200
 breakingTorque = 200
 fuelCrossFeed = True
 maxTemp = 2000 // = 3000
+fuelCrossFeed = True
 bulkheadProfiles = size1, srf
 	tags = #autoLOC_500498 //#autoLOC_500498 = fuel fueltank ?lfo liquid oxidizer propellant rocket tank
 

--- a/GameData/MunarIndustries/Parts/FuelTank/Radial_LG/Radial_Wedge_LG_M.cfg
+++ b/GameData/MunarIndustries/Parts/FuelTank/Radial_LG/Radial_Wedge_LG_M.cfg
@@ -43,6 +43,7 @@ breakingForce = 200
 breakingTorque = 200
 fuelCrossFeed = True
 maxTemp = 2000 // = 3000
+fuelCrossFeed = True
 bulkheadProfiles = size1, srf
 	tags = #autoLOC_500498 //#autoLOC_500498 = fuel fueltank ?lfo liquid oxidizer propellant rocket tank
 

--- a/GameData/MunarIndustries/Parts/FuelTank/Three75M_Tanks/Pancake.cfg
+++ b/GameData/MunarIndustries/Parts/FuelTank/Three75M_Tanks/Pancake.cfg
@@ -42,6 +42,7 @@ crashTolerance = 6
 breakingForce = 200
 breakingTorque = 200
 maxTemp = 2000 // = 2900
+fuelCrossFeed = True
 bulkheadProfiles = size3, srf
 	tags = #autoLOC_500498 //#autoLOC_500498 = fuel fueltank ?lfo liquid oxidizer propellant rocket tank
 

--- a/GameData/MunarIndustries/Parts/FuelTank/Three75M_Tanks/Three75M_Adapt.cfg
+++ b/GameData/MunarIndustries/Parts/FuelTank/Three75M_Tanks/Three75M_Adapt.cfg
@@ -42,6 +42,7 @@ crashTolerance = 6
 breakingForce = 200
 breakingTorque = 200
 maxTemp = 2000 // = 2900
+fuelCrossFeed = True
 bulkheadProfiles = size3, size2, srf
 	tags = #autoLOC_500498 //#autoLOC_500498 = fuel fueltank ?lfo liquid oxidizer propellant rocket tank
 

--- a/GameData/MunarIndustries/Parts/FuelTank/Three75M_Tanks/Three75M_Cone.cfg
+++ b/GameData/MunarIndustries/Parts/FuelTank/Three75M_Tanks/Three75M_Cone.cfg
@@ -41,6 +41,7 @@ crashTolerance = 6
 breakingForce = 200
 breakingTorque = 200
 maxTemp = 2000 // = 2900
+fuelCrossFeed = True
 bulkheadProfiles = size3, size2, srf
 	tags = #autoLOC_500498 //#autoLOC_500498 = fuel fueltank ?lfo liquid oxidizer propellant rocket tank
 

--- a/GameData/MunarIndustries/Parts/FuelTank/Three75M_Tanks/Three75M_Dome.cfg
+++ b/GameData/MunarIndustries/Parts/FuelTank/Three75M_Tanks/Three75M_Dome.cfg
@@ -42,6 +42,7 @@ crashTolerance = 6
 breakingForce = 200
 breakingTorque = 200
 maxTemp = 2000 // = 2900
+fuelCrossFeed = True
 bulkheadProfiles = size3, size2, srf
 	tags = #autoLOC_500498 //#autoLOC_500498 = fuel fueltank ?lfo liquid oxidizer propellant rocket tank
 

--- a/GameData/MunarIndustries/Parts/FuelTank/Toroid_LG/Toroid_LG.cfg
+++ b/GameData/MunarIndustries/Parts/FuelTank/Toroid_LG/Toroid_LG.cfg
@@ -38,6 +38,7 @@ crashTolerance = 6
 breakingForce = 200
 breakingTorque = 200
 maxTemp = 2000 // = 2900
+fuelCrossFeed = True
 bulkheadProfiles = size3, srf
 	tags = #autoLOC_500498 //#autoLOC_500498 = fuel fueltank ?lfo liquid oxidizer propellant rocket tank
 

--- a/GameData/MunarIndustries/Parts/FuelTank/Toroid_SM/Toroid_SM.cfg
+++ b/GameData/MunarIndustries/Parts/FuelTank/Toroid_SM/Toroid_SM.cfg
@@ -40,6 +40,7 @@ crashTolerance = 6
 breakingForce = 50
 breakingTorque = 50
 maxTemp = 2000 // = 2900
+fuelCrossFeed = True
 bulkheadProfiles = size2, srf
 	tags = #autoLOC_500498 //#autoLOC_500498 = fuel fueltank ?lfo liquid oxidizer propellant rocket tank
 

--- a/GameData/MunarIndustries/Parts/FuelTank/Two5M_Tanks/Piepan.cfg
+++ b/GameData/MunarIndustries/Parts/FuelTank/Two5M_Tanks/Piepan.cfg
@@ -41,6 +41,7 @@ crashTolerance = 6
 breakingForce = 200
 breakingTorque = 200
 maxTemp = 2000 // = 2900
+fuelCrossFeed = True
 bulkheadProfiles = size2, srf
 	tags = #autoLOC_500498 //#autoLOC_500498 = fuel fueltank ?lfo liquid oxidizer propellant rocket tank
 

--- a/GameData/MunarIndustries/Parts/FuelTank/Two5M_Tanks/Two5M_Adapt.cfg
+++ b/GameData/MunarIndustries/Parts/FuelTank/Two5M_Tanks/Two5M_Adapt.cfg
@@ -41,6 +41,7 @@ crashTolerance = 6
 breakingForce = 200
 breakingTorque = 200
 maxTemp = 2000 // = 2900
+fuelCrossFeed = True
 bulkheadProfiles = size2, size1, srf
 	tags = #autoLOC_500498 //#autoLOC_500498 = fuel fueltank ?lfo liquid oxidizer propellant rocket tank
 

--- a/GameData/MunarIndustries/Parts/FuelTank/Two5M_Tanks/Two5M_Cone.cfg
+++ b/GameData/MunarIndustries/Parts/FuelTank/Two5M_Tanks/Two5M_Cone.cfg
@@ -40,6 +40,7 @@ crashTolerance = 6
 breakingForce = 200
 breakingTorque = 200
 maxTemp = 2000 // = 2900
+fuelCrossFeed = True
 bulkheadProfiles = size2, size1, srf
 	tags = #autoLOC_500498 //#autoLOC_500498 = fuel fueltank ?lfo liquid oxidizer propellant rocket tank
 

--- a/GameData/MunarIndustries/Parts/FuelTank/Two5M_Tanks/Two5M_Dome.cfg
+++ b/GameData/MunarIndustries/Parts/FuelTank/Two5M_Tanks/Two5M_Dome.cfg
@@ -40,6 +40,7 @@ crashTolerance = 6
 breakingForce = 200
 breakingTorque = 200
 maxTemp = 2000 // = 2900
+fuelCrossFeed = True
 bulkheadProfiles = size2, size1, srf
 	tags = #autoLOC_500498 //#autoLOC_500498 = fuel fueltank ?lfo liquid oxidizer propellant rocket tank
 

--- a/GameData/MunarIndustries/Parts/FuelTank/Zero625M_Tanks/Oscar_Cone.cfg
+++ b/GameData/MunarIndustries/Parts/FuelTank/Zero625M_Tanks/Oscar_Cone.cfg
@@ -38,6 +38,7 @@ crashTolerance = 6
 breakingForce = 50
 breakingTorque = 50
 maxTemp = 2000 // = 2900
+fuelCrossFeed = True
 bulkheadProfiles = size0, srf
 	tags = #autoLOC_500498 //#autoLOC_500498 = fuel fueltank ?lfo liquid oxidizer propellant rocket tank
 

--- a/GameData/MunarIndustries/Parts/FuelTank/Zero625M_Tanks/Oscar_Dome.cfg
+++ b/GameData/MunarIndustries/Parts/FuelTank/Zero625M_Tanks/Oscar_Dome.cfg
@@ -39,6 +39,7 @@ crashTolerance = 6
 breakingForce = 50
 breakingTorque = 50
 maxTemp = 2000 // = 2900
+fuelCrossFeed = True
 bulkheadProfiles = size0, srf
 	tags = #autoLOC_500498 //#autoLOC_500498 = fuel fueltank ?lfo liquid oxidizer propellant rocket tank
 

--- a/GameData/MunarIndustries/Parts/FuelTank/Zero625M_Tanks/Thermos.cfg
+++ b/GameData/MunarIndustries/Parts/FuelTank/Zero625M_Tanks/Thermos.cfg
@@ -39,6 +39,7 @@ crashTolerance = 6
 breakingForce = 50
 breakingTorque = 50
 maxTemp = 2000 // = 2900
+fuelCrossFeed = True
 bulkheadProfiles = size0, srf
 	tags = #autoLOC_500498 //#autoLOC_500498 = fuel fueltank ?lfo liquid oxidizer propellant rocket tank
 

--- a/GameData/MunarIndustries/Parts/FuelTank/Zero625M_Tanks_LT/Oscar_Dome_LT.cfg
+++ b/GameData/MunarIndustries/Parts/FuelTank/Zero625M_Tanks_LT/Oscar_Dome_LT.cfg
@@ -39,6 +39,7 @@ crashTolerance = 6
 breakingForce = 50
 breakingTorque = 50
 maxTemp = 800 // = 1200
+fuelCrossFeed = True
 bulkheadProfiles = size0, srf
 	tags = #autoLOC_500498 //#autoLOC_500498 = fuel fueltank ?lfo liquid oxidizer propellant rocket tank
 

--- a/GameData/MunarIndustries/Parts/FuelTank/Zero625M_Tanks_LT/Oscar_LT.cfg
+++ b/GameData/MunarIndustries/Parts/FuelTank/Zero625M_Tanks_LT/Oscar_LT.cfg
@@ -39,6 +39,7 @@ crashTolerance = 6
 breakingForce = 50
 breakingTorque = 50
 maxTemp = 800 // = 1200
+fuelCrossFeed = True
 bulkheadProfiles = size0, srf
 	tags = #autoLOC_500498 //#autoLOC_500498 = fuel fueltank ?lfo liquid oxidizer propellant rocket tank
 


### PR DESCRIPTION
Hopefully fixing one little frustration with this awesome set of parts.

Currently only some of the radial parts have "fuelCrossFeed = True" set, this sets all of the stack and radial LFO parts to have that attribute, updates the forum links for referenced mods, and proposes the version number increment by x.x.x.1. 